### PR TITLE
make dark the default theme

### DIFF
--- a/app/_store/subscriptions.ts
+++ b/app/_store/subscriptions.ts
@@ -48,7 +48,7 @@ export function initializeSubscriptions(store: AppStore) {
   setRdt(rdtInstance);
 
   // Set connect button theme
-  rdtInstance.buttonApi.setTheme("black");
+  rdtInstance.buttonApi.setTheme("white");
 
   console.log("INITIALIZATION DONE");
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,15 +3,8 @@
 @tailwind utilities;
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 body {


### PR DESCRIPTION
For the MVP we should only have a single theme, and not support light / dark mode. 

Since most of the team likes dark I switched to dark by default (although I loved the light themed style). 

But dark looks dope too!